### PR TITLE
fix: Handle missing track index numbers in Plex library

### DIFF
--- a/src/plex_music_ratings_sync/sync.py
+++ b/src/plex_music_ratings_sync/sync.py
@@ -49,8 +49,10 @@ class RatingSync:
 
         file_path = Path(item.media[0].parts[0].file)
 
+        track_index = item.index if item.index is not None else 0
+
         log_info(
-            f"Track: **{item.index:02d}. {item.title}** __({file_path.name})__",
+            f"Track: **{track_index:02d}. {item.title}** __({file_path.name})__",
             3,
         )
 


### PR DESCRIPTION
## Overview

When processing tracks without an index number (track number), the sync process fails with a `TypeError`. This happens because the code tries to format a `None` value with `:02d`. To prevent this formatting error, a null check for `item.index` was added with a fallback to `0` when the index is missing.

### Reference

Fixes https://github.com/rfgamaral/PlexMusicRatingsSync/issues/2.