### PR TITLE
fix!: Bump minimum Python version to 3.9 for `filelock` compatibility 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "1.1.3"
 readme = "README.md"
 authors = [{ name = "Ricardo Amaral", email = "hello@ricardoamaral.net" }]
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Environment :: Console",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Bump minimum Python version to 3.9 to match `filelock==3.17.0` dependency requirement.