### PR TITLE
feat: Add environment variable overrides for plex config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,39 @@ docker compose run --rm plex-music-ratings-sync sync
     docker compose run --rm plex-music-ratings-sync export
     ```
 
+### Environment Variables
+
+You can override YAML configuration values using environment variables. This is useful for container orchestrators (Kubernetes, Docker Swarm), CI/CD pipelines, or any environment where managing config files is impractical.
+
+| Variable | Description | Example |
+|---|---|---|
+| `PMRS_PLEX_URL` | Plex server URL | `http://192.168.1.100:32400` |
+| `PMRS_PLEX_TOKEN` | Plex authentication token | `your-plex-token` |
+| `PMRS_PLEX_LIBRARIES` | Comma-separated library names | `Music,Audiobooks` |
+
+**Precedence:** The YAML config file is always loaded first. Environment variables, when set, override the corresponding YAML values. A log message is emitted when overrides are active.
+
+> [!NOTE]
+> The path-related variables `PMRS_CONFIG_DIR`, `PMRS_LOG_DIR`, and `PMRS_CACHE_DIR` control directory locations and are separate from the config override variables above.
+
+Example usage with Docker Compose:
+
+```yaml
+services:
+  plex-music-ratings-sync:
+    image: ghcr.io/rfgamaral/plex-music-ratings-sync
+    container_name: plex-music-ratings-sync
+    network_mode: bridge
+    restart: on-failure:2
+    environment:
+      - PMRS_PLEX_URL=http://192.168.1.100:32400
+      - PMRS_PLEX_TOKEN=your-plex-token
+      - PMRS_PLEX_LIBRARIES=Music,Audiobooks
+    volumes:
+      - /host/app/data:/app/data
+      - /host/plex/music:/plex/music
+```
+
 ### Automated Synchronization
 
 You can automate the synchronization process to run periodically using different methods depending on your installation.
@@ -265,6 +298,12 @@ The cache is automatically managed and requires no configuration. If you need to
 - `--clear-cache`: Delete the cached data before processing
 
 The cache file location is shown in the output of `plex-music-ratings-sync info`.
+
+### Can I use environment variables instead of the config file?
+
+Yes. You can set `PMRS_PLEX_URL`, `PMRS_PLEX_TOKEN`, and `PMRS_PLEX_LIBRARIES` to override the corresponding values from the YAML config file. The YAML file is still loaded (and created from template if it doesn't exist), but environment variables take precedence when set. A log message confirms when overrides are active.
+
+This is especially useful for Docker, Kubernetes, or any deployment where injecting environment variables is easier than mounting config files.
 
 ## License
 

--- a/src/plex_music_ratings_sync/config.py
+++ b/src/plex_music_ratings_sync/config.py
@@ -1,9 +1,10 @@
 import sys
+from os import getenv
 from shutil import copyfile
 
 import yaml
 
-from plex_music_ratings_sync.logger import log_error
+from plex_music_ratings_sync.logger import log_error, log_info
 from plex_music_ratings_sync.util.paths import (
     get_config_dir,
     get_config_file_path,
@@ -12,6 +13,13 @@ from plex_music_ratings_sync.util.paths import (
 
 _config = None
 """User configuration data."""
+
+_ENV_OVERRIDES = {
+    "PMRS_PLEX_URL": "url",
+    "PMRS_PLEX_TOKEN": "token",
+    "PMRS_PLEX_LIBRARIES": "libraries",
+}
+"""Mapping of environment variable names to plex config keys."""
 
 
 def _create_config(config_file_path):
@@ -38,15 +46,67 @@ def init_config():
     with open(config_file_path, "r") as config_file:
         _config = yaml.safe_load(config_file)
 
+    if not isinstance(_config, dict):
+        _config = {}
+
+    _apply_env_overrides()
+
+
+def _apply_env_overrides():
+    """Override configuration values with PMRS_PLEX_* environment variables."""
+    overrides = {}
+
+    for env_var, key in _ENV_OVERRIDES.items():
+        value = getenv(env_var)
+
+        if value is None:
+            continue
+
+        value = value.strip()
+
+        if not value:
+            continue
+
+        overrides[key] = value
+
+    if not overrides:
+        return
+
+    if not isinstance(_config.get("plex"), dict):
+        _config["plex"] = {}
+
+    for key, value in overrides.items():
+        if key == "libraries":
+            _config["plex"][key] = [
+                lib.strip() for lib in value.split(",") if lib.strip()
+            ]
+        else:
+            _config["plex"][key] = value
+
 
 def get_plex_config():
     """Retrieve the Plex configuration."""
     plex_config = _config.get("plex", {})
 
+    overridden = [
+        key for env_var, key in _ENV_OVERRIDES.items() if getenv(env_var, "").strip()
+    ]
+
+    if overridden:
+        log_info(f"Config overridden by environment: **{', '.join(overridden)}**")
+
     if not isinstance(plex_config.get("url"), str) or not isinstance(
         plex_config.get("token"), str
     ):
         log_error("The Plex configuration is not valid")
+        sys.exit(1)
+
+    libraries = plex_config.get("libraries")
+
+    if not isinstance(libraries, list) or not all(
+        isinstance(lib, str) and lib.strip() for lib in libraries
+    ):
+        log_error("The Plex libraries configuration is not valid")
         sys.exit(1)
 
     return plex_config


### PR DESCRIPTION
## Overview

Allow Plex configuration values to be overridden via environment variables (`PMRS_PLEX_URL`, `PMRS_PLEX_TOKEN`, `PMRS_PLEX_LIBRARIES`), following the existing `PMRS_` prefix convention. This makes the tool easier to deploy in environments where managing config files is impractical, such as Kubernetes, Docker Swarm, or CI/CD pipelines.

The YAML config file remains the primary mechanism and is always loaded first. When set, environment variables override the corresponding values, and a log message is emitted to confirm which keys were overridden. Values are stripped of whitespace to handle common secret injection edge cases, and empty library names from trailing commas are filtered out. A `libraries` validation was also added to `get_plex_config()` to catch missing or invalid library configurations early.

### Reference

Inspired by #22.